### PR TITLE
yaml.load without Loader is no longer available

### DIFF
--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -429,7 +429,7 @@ if __name__ == '__main__':
         import yaml
         from pathlib import Path
         from easydict import EasyDict
-        dataset_cfg = EasyDict(yaml.load(open(sys.argv[2])))
+        dataset_cfg = EasyDict(yaml.safe_load(open(sys.argv[2])))
         ROOT_DIR = (Path(__file__).resolve().parent / '../../../').resolve()
         create_kitti_infos(
             dataset_cfg=dataset_cfg,


### PR DESCRIPTION
Ref: https://github.com/yaml/pyyaml/commit/c2743653bc89e42679ba097b4f9888db47c61d63

Since PyYAML 6.0, yaml.load without Loader is no longer available. We have to use safe_load instead.